### PR TITLE
Add prompts support to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,9 @@ npm run test:coverage
 ### Linting and Formatting
 
 ```bash
+# Run all checks (format, lint, typecheck, test, build)
+npm run check
+
 # Run linter
 npm run lint
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:tests": "tsc --noEmit --project tsconfig.test.json",
     "typecheck:all": "npm run typecheck && npm run typecheck:tests",
+    "check": "npm run format && npm run lint:fix && npm run typecheck:all && npm test && npm run build",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/src/apiPaths.ts
+++ b/src/apiPaths.ts
@@ -17,6 +17,14 @@ export const API_PATHS = {
   TOOL_CALL: (serverName: string, toolName: string) =>
     `${SERVERS_BASE}/${encodeURIComponent(serverName)}/tools/${encodeURIComponent(toolName)}`,
 
+  // Prompts
+  SERVER_PROMPTS: (serverName: string, cursor?: string) => {
+    const base = `${SERVERS_BASE}/${encodeURIComponent(serverName)}/prompts`;
+    return cursor ? `${base}?cursor=${encodeURIComponent(cursor)}` : base;
+  },
+  PROMPT_GET_GENERATED: (serverName: string, promptName: string) =>
+    `${SERVERS_BASE}/${encodeURIComponent(serverName)}/prompts/${encodeURIComponent(promptName)}`,
+
   // Health
   HEALTH_ALL: HEALTH_SERVERS_BASE,
   HEALTH_SERVER: (serverName: string) =>

--- a/src/client.ts
+++ b/src/client.ts
@@ -406,22 +406,18 @@ export class McpdClient {
     );
 
     // Process results and transform prompt names.
-    const allPrompts: Prompt[] = [];
-    for (const result of results) {
-      if (result.status === "fulfilled") {
-        const { serverName, prompts } = result.value;
-        // Transform prompt names to serverName__promptName format.
-        for (const prompt of prompts) {
-          allPrompts.push({
-            ...prompt,
-            name: `${serverName}__${prompt.name}`,
-          });
-        }
-      } else {
-        // If we can't get prompts for a server, skip it with a warning.
-        console.warn(`Failed to get prompts for server:`, result.reason);
-      }
-    }
+const allPrompts: Prompt[] = results.flatMap(result => {
+  if (result.status === "fulfilled") {
+    const { serverName, prompts } = result.value;
+    return prompts.map(prompt => ({
+      ...prompt,
+      name: `${serverName}__${prompt.name}`,
+    }));
+  } else {
+    console.warn(`Failed to get prompts for server:`, result.reason);
+    return []; // Return an empty array for rejected promises
+  }
+});
 
     return allPrompts;
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -535,12 +535,9 @@ export class McpdClient {
   /**
    * Internal method to generate a prompt on a server.
    *
-   * ⚠️ This method is truly private and cannot be accessed by SDK consumers.
-   * Use the fluent API instead: `client.servers.foo.prompts.bar(args)`
-   *
    * This method is used internally by:
    * - PromptsNamespace (via dependency injection)
-   * - Server.getPrompt() (via dependency injection)
+   * - Server.generatePrompt() (via dependency injection)
    *
    * @param serverName - The name of the server
    * @param promptName - The exact name of the prompt
@@ -718,11 +715,8 @@ export class McpdClient {
   /**
    * Internal method to perform a tool call on a server.
    *
-   * ⚠️ This method is truly private and cannot be accessed by SDK consumers.
-   * Use the fluent API instead: `client.servers.foo.tools.bar(args)`
-   *
    * This method is used internally by:
-   * - ToolsProxy (via dependency injection)
+   * - ToolsNamespace (via dependency injection)
    * - FunctionBuilder (via dependency injection)
    *
    * @param serverName - The name of the server

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,6 +266,24 @@ export type PerformCallFn = (
 export type GetToolsFn = (serverName: string) => Promise<Tool[]>;
 
 /**
+ * Function signature for getting prompt templates from a server.
+ * This is injected into proxy classes via dependency injection.
+ * @internal
+ */
+export type GetPromptsFn = (serverName: string) => Promise<Prompt[]>;
+
+/**
+ * Function signature for generating a prompt from a template.
+ * This is injected into proxy classes via dependency injection.
+ * @internal
+ */
+export type GeneratePromptFn = (
+  serverName: string,
+  promptName: string,
+  args?: Record<string, string>,
+) => Promise<GeneratePromptResponseBody>;
+
+/**
  * MCP resource definition.
  */
 export interface Resource {


### PR DESCRIPTION
* Prompts can be accessed:
  *  via dynamic proxy syntax ... `client.servers.foo.prompts.bar(args)`
  * explicit methods ... `client.generatePrompt("foo__bar", args)` 
  * explicit methods ... `client.servers.foo.generatePrompt(bar, args)`)
* Client-level methods namespace prompt names as  `serverName__promptName` to prevent collisions across multiple servers.
* API documentation in README.