### PR TITLE
Fix npm trusted publishing - upgrade npm CLI to latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,10 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install latest npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Problem

npm trusted publishing was failing with:
- ✅ Provenance signing successful 
- ❌ Package publish failing with 404/auth errors

## Root Cause

GitHub-hosted runners ship with npm 10.x, but **npm trusted publishing requires npm CLI v11.5.1 or later**.

## Solution

1. Added step to upgrade npm to latest version before publishing
2. Restored `registry-url` to setup-node for proper `.npmrc` configuration

## Testing

After merging, will delete and recreate v0.0.2 release to verify trusted publishing works.

## References

- https://docs.npmjs.com/trusted-publishers/
- npm trusted publishing requires npm CLI v11.5.1+