### PR TITLE
Improve lint commands and CI consistency

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,6 +19,9 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install npm 11.6.2
+        run: npm install -g npm@11.6.2
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,9 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install npm 11.6.2
+        run: npm install -g npm@11.6.2
+
       - name: Install dependencies
         run: npm ci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.9.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1489,6 +1489,7 @@
       "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -1708,6 +1709,7 @@
       "integrity": "sha512-CsGG2P3I5y48RPMfprQGfy4JPRZ6csfC3ltBZSRItG3ngggmNY/qs2uZKp4p9VbrpqNNSMzUZNFZKzgOGnd/VA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1748,6 +1750,7 @@
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -2206,6 +2209,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2671,6 +2675,7 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3409,6 +3414,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -4073,6 +4079,7 @@
       "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4466,6 +4473,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4592,6 +4600,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4671,6 +4680,7 @@
       "integrity": "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4814,6 +4824,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4827,6 +4838,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "lint": "eslint . && npm run typecheck:all",
-    "lint:fix": "eslint . --fix",
+    "lint": "npm run format:check && eslint . && npm run typecheck:all",
+    "lint:fix": "npm run format && eslint . --fix && npm run typecheck:all",
     "format": "prettier --write \"**/*.{ts,tsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,json,md}\"",
     "typecheck": "tsc --noEmit",
@@ -53,7 +53,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.9.0"
   },
   "dependencies": {
     "lru-cache": "^11.2.2",
@@ -77,5 +77,5 @@
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^3.2.4"
   },
-  "packageManager": "npm@10.0.0"
+  "packageManager": "npm@11.6.2"
 }


### PR DESCRIPTION
## Summary

This PR improves the development workflow by ensuring that running `npm run lint:fix` locally catches the same issues as CI, preventing formatting and package-lock inconsistencies.

## Changes

- **Updated lint commands**:
  - `lint`: now runs format check → eslint → typecheck
  - `lint:fix`: now runs format → eslint fix → typecheck
  
- **Updated `packageManager` field**: Changed from `npm@10.0.0` to `npm@11.6.2` for consistency

- **Updated Node engine requirement**: Changed from `>=22.0.0` to `>=22.9.0` for npm@11.6.2 compatibility

- **Updated GitHub Actions workflows**: Both lint and test workflows now explicitly install `npm@11.6.2`

## Benefits

- Developers catch formatting, linting, AND type errors locally before pushing
- No more "package-lock.json is out of date" CI failures due to npm version mismatches
- CI runs are more predictable and consistent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Node.js engine requirement to version 22.9.0 or higher.
  * Updated npm package manager to version 11.6.2.
  * Enhanced continuous integration workflows to ensure consistent toolchain setup across lint and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->