### PR TITLE
Add tool name filtering to `getAgentTools()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,8 +359,15 @@ if (await client.isServerHealthy("time")) {
 
 Generate callable functions that work directly with AI agent frameworks. No conversion layers needed.
 
+**Why filter tools?**
+
+AI agents perform better with focused tool sets.
+Tool filtering enables progressive disclosure - operators can expose a subset of server tools via `mcpd` configuration,
+then agents can further narrow down to only the tools needed for their specific task.
+This prevents overwhelming the model's context window and improves response quality.
+
 ```typescript
-// Options: { servers?: string[], format?: 'array' | 'object' | 'map' }
+// Options: { servers?: string[], tools?: string[], format?: 'array' | 'object' | 'map' }
 // Default format is 'array' (for LangChain)
 
 // Use with LangChain JS (array format is default)
@@ -395,6 +402,28 @@ const result = await generateText({
 const timeTools = await client.getAgentTools({
   servers: ["time"],
   format: "array",
+});
+
+// Filter by tool names (cross-cutting across all servers)
+const mathTools = await client.getAgentTools({
+  tools: ["add", "multiply"],
+});
+
+// Filter by qualified tool names (server-specific)
+const specificTools = await client.getAgentTools({
+  tools: ["time__get_current_time", "math__add"],
+});
+
+// Combine server and tool filtering
+const filteredTools = await client.getAgentTools({
+  servers: ["time", "math"],
+  tools: ["add", "get_current_time"],
+});
+
+// Tool filtering works with different formats
+const toolsObject = await client.getAgentTools({
+  tools: ["add", "multiply"],
+  format: "object",
 });
 
 // Use with Map for efficient lookups

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,6 +239,16 @@ export interface AgentToolsOptions {
   servers?: string[];
 
   /**
+   * Optional list of tool names to filter by. Supports both:
+   * - Raw tool names: 'get_current_time' (matches tool across all servers)
+   * - Server-prefixed names: 'time__get_current_time' (server + TOOL_SEPARATOR + tool)
+   * If not specified, returns all tools from selected servers.
+   * @example ['add', 'multiply']
+   * @example ['time__get_current_time', 'math__add']
+   */
+  tools?: string[];
+
+  /**
    * Output format for the tools.
    * - 'array': Returns array of functions (default, for LangChain)
    * - 'object': Returns object keyed by tool name (for Vercel AI SDK)


### PR DESCRIPTION
Adds `tools` parameter to `getAgentTools()` for filtering by tool name.

Supports two formats:
- Raw: `tools: ['add']` - matches tool across all servers
- Prefixed: `tools: ['time__get_current_time']` - matches specific server+tool

Can be combined with server filtering for progressive disclosure (operators filter servers, agents filter tools).

Introduces `TOOL_SEPARATOR` constant and validation for prefixed format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side tool-name filtering when retrieving agent tools; accepts raw names or server-prefixed identifiers and can be combined with server and format options.

* **API**
  * Public API updated to accept an optional tools?: string[] option alongside servers? and format?.

* **Documentation**
  * README updated with cross-server, server-qualified and mixed-filter examples and notes on output formats (default: array).

* **Tests**
  * New unit tests covering varied filtering scenarios and all output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->