### PR TITLE
Add PipelineError for plugin pipeline failures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,12 +22,16 @@ export {
   McpdError,
   AuthenticationError,
   ConnectionError,
+  PipelineError,
+  PIPELINE_FLOW_REQUEST,
+  PIPELINE_FLOW_RESPONSE,
   ServerNotFoundError,
   ServerUnhealthyError,
   TimeoutError,
   ToolExecutionError,
   ToolNotFoundError,
   ValidationError,
+  type PipelineFlow,
 } from "./errors";
 
 // Export type definitions

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpdClient } from "../../src/client";
-import { ConnectionError, AuthenticationError } from "../../src/errors";
+import {
+  ConnectionError,
+  AuthenticationError,
+  McpdError,
+  PipelineError,
+} from "../../src/errors";
 import { HealthStatusHelpers } from "../../src/types";
 import { createFetchMock } from "./utils/mockApi";
 import { API_PATHS } from "../../src/apiPaths";
@@ -1284,6 +1289,171 @@ describe("McpdClient", () => {
       expect(customWarn).toHaveBeenCalledWith(
         "Skipping unhealthy server 'unhealthy' with status 'timeout'",
       );
+    });
+  });
+
+  describe("PipelineError handling", () => {
+    it("should throw PipelineError for response pipeline failure", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers({
+          "Mcpd-Error-Type": "response-pipeline-failure",
+        }),
+        text: async () => "Response processing failed\n",
+      });
+
+      await expect(client.listServers()).rejects.toThrow(PipelineError);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers({
+          "Mcpd-Error-Type": "response-pipeline-failure",
+        }),
+        text: async () => "Response processing failed\n",
+      });
+
+      try {
+        await client.listServers();
+      } catch (error) {
+        expect(error).toBeInstanceOf(PipelineError);
+        const pipelineError = error as PipelineError;
+        expect(pipelineError.pipelineFlow).toBe("response");
+        expect(pipelineError.message).toContain("Response processing failed");
+      }
+    });
+
+    it("should throw PipelineError for request pipeline failure", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers({
+          "Mcpd-Error-Type": "request-pipeline-failure",
+        }),
+        text: async () => "Request processing failed\n",
+      });
+
+      try {
+        await client.listServers();
+      } catch (error) {
+        expect(error).toBeInstanceOf(PipelineError);
+        const pipelineError = error as PipelineError;
+        expect(pipelineError.pipelineFlow).toBe("request");
+        expect(pipelineError.message).toContain("Request processing failed");
+      }
+    });
+
+    it("should throw McpdError for 500 without Mcpd-Error-Type header", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers(),
+        text: async () => "Internal Server Error",
+      });
+
+      try {
+        await client.listServers();
+      } catch (error) {
+        expect(error).not.toBeInstanceOf(PipelineError);
+        expect(error).toBeInstanceOf(McpdError);
+      }
+    });
+
+    it("should handle case-insensitive header value", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers({
+          "Mcpd-Error-Type": "RESPONSE-PIPELINE-FAILURE",
+        }),
+        text: async () => "Response processing failed\n",
+      });
+
+      try {
+        await client.listServers();
+      } catch (error) {
+        expect(error).toBeInstanceOf(PipelineError);
+        const pipelineError = error as PipelineError;
+        expect(pipelineError.pipelineFlow).toBe("response");
+      }
+    });
+
+    it("should enrich PipelineError with server and tool context in performCall", async () => {
+      // First mock: health check for ensureServerHealthy.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          name: "time",
+          status: "ok",
+          latency: "2ms",
+          lastChecked: "2025-10-07T15:00:00Z",
+          lastSuccessful: "2025-10-07T15:00:00Z",
+        }),
+      });
+
+      // Second mock: tools list for getTools (to verify tool exists).
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tools: [
+            {
+              name: "get_current_time",
+              description: "Get current time",
+              inputSchema: {
+                type: "object",
+                properties: { timezone: { type: "string" } },
+              },
+            },
+          ],
+        }),
+      });
+
+      // Third mock: tool call returns pipeline error.
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers({
+          "Mcpd-Error-Type": "response-pipeline-failure",
+        }),
+        text: async () => "Response processing failed\n",
+      });
+
+      try {
+        await client.servers.time!.tools.get_current_time!({ timezone: "UTC" });
+      } catch (error) {
+        expect(error).toBeInstanceOf(PipelineError);
+        const pipelineError = error as PipelineError;
+        expect(pipelineError.pipelineFlow).toBe("response");
+        expect(pipelineError.serverName).toBe("time");
+        expect(pipelineError.operation).toBe("time.get_current_time");
+        expect(pipelineError.message).toContain("Response processing failed");
+      }
+    });
+
+    it("should not throw PipelineError for other 500 errors", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers({
+          "Mcpd-Error-Type": "some-other-error-type",
+        }),
+        text: async () => "Some other error",
+      });
+
+      try {
+        await client.listServers();
+      } catch (error) {
+        expect(error).not.toBeInstanceOf(PipelineError);
+        expect(error).toBeInstanceOf(McpdError);
+      }
     });
   });
 });

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -1304,26 +1304,12 @@ describe("McpdClient", () => {
         text: async () => "Response processing failed\n",
       });
 
-      await expect(client.listServers()).rejects.toThrow(PipelineError);
+      const error = await client.listServers().catch((e: unknown) => e);
 
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: "Internal Server Error",
-        headers: new Headers({
-          "Mcpd-Error-Type": "response-pipeline-failure",
-        }),
-        text: async () => "Response processing failed\n",
-      });
-
-      try {
-        await client.listServers();
-      } catch (error) {
-        expect(error).toBeInstanceOf(PipelineError);
-        const pipelineError = error as PipelineError;
-        expect(pipelineError.pipelineFlow).toBe("response");
-        expect(pipelineError.message).toContain("Response processing failed");
-      }
+      expect(error).toBeInstanceOf(PipelineError);
+      const pipelineError = error as PipelineError;
+      expect(pipelineError.pipelineFlow).toBe("response");
+      expect(pipelineError.message).toContain("Response processing failed");
     });
 
     it("should throw PipelineError for request pipeline failure", async () => {
@@ -1337,14 +1323,12 @@ describe("McpdClient", () => {
         text: async () => "Request processing failed\n",
       });
 
-      try {
-        await client.listServers();
-      } catch (error) {
-        expect(error).toBeInstanceOf(PipelineError);
-        const pipelineError = error as PipelineError;
-        expect(pipelineError.pipelineFlow).toBe("request");
-        expect(pipelineError.message).toContain("Request processing failed");
-      }
+      const error = await client.listServers().catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(PipelineError);
+      const pipelineError = error as PipelineError;
+      expect(pipelineError.pipelineFlow).toBe("request");
+      expect(pipelineError.message).toContain("Request processing failed");
     });
 
     it("should throw McpdError for 500 without Mcpd-Error-Type header", async () => {
@@ -1356,12 +1340,10 @@ describe("McpdClient", () => {
         text: async () => "Internal Server Error",
       });
 
-      try {
-        await client.listServers();
-      } catch (error) {
-        expect(error).not.toBeInstanceOf(PipelineError);
-        expect(error).toBeInstanceOf(McpdError);
-      }
+      const error = await client.listServers().catch((e: unknown) => e);
+
+      expect(error).not.toBeInstanceOf(PipelineError);
+      expect(error).toBeInstanceOf(McpdError);
     });
 
     it("should handle case-insensitive header value", async () => {
@@ -1375,13 +1357,11 @@ describe("McpdClient", () => {
         text: async () => "Response processing failed\n",
       });
 
-      try {
-        await client.listServers();
-      } catch (error) {
-        expect(error).toBeInstanceOf(PipelineError);
-        const pipelineError = error as PipelineError;
-        expect(pipelineError.pipelineFlow).toBe("response");
-      }
+      const error = await client.listServers().catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(PipelineError);
+      const pipelineError = error as PipelineError;
+      expect(pipelineError.pipelineFlow).toBe("response");
     });
 
     it("should enrich PipelineError with server and tool context in performCall", async () => {
@@ -1425,16 +1405,16 @@ describe("McpdClient", () => {
         text: async () => "Response processing failed\n",
       });
 
-      try {
-        await client.servers.time!.tools.get_current_time!({ timezone: "UTC" });
-      } catch (error) {
-        expect(error).toBeInstanceOf(PipelineError);
-        const pipelineError = error as PipelineError;
-        expect(pipelineError.pipelineFlow).toBe("response");
-        expect(pipelineError.serverName).toBe("time");
-        expect(pipelineError.operation).toBe("time.get_current_time");
-        expect(pipelineError.message).toContain("Response processing failed");
-      }
+      const error = await client.servers.time!.tools.get_current_time!({
+        timezone: "UTC",
+      }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(PipelineError);
+      const pipelineError = error as PipelineError;
+      expect(pipelineError.pipelineFlow).toBe("response");
+      expect(pipelineError.serverName).toBe("time");
+      expect(pipelineError.operation).toBe("time.get_current_time");
+      expect(pipelineError.message).toContain("Response processing failed");
     });
 
     it("should not throw PipelineError for other 500 errors", async () => {
@@ -1448,12 +1428,10 @@ describe("McpdClient", () => {
         text: async () => "Some other error",
       });
 
-      try {
-        await client.listServers();
-      } catch (error) {
-        expect(error).not.toBeInstanceOf(PipelineError);
-        expect(error).toBeInstanceOf(McpdError);
-      }
+      const error = await client.listServers().catch((e: unknown) => e);
+
+      expect(error).not.toBeInstanceOf(PipelineError);
+      expect(error).toBeInstanceOf(McpdError);
     });
   });
 });


### PR DESCRIPTION
Adds support for detecting and handling `mcpd` plugin pipeline failures:

- Add PipelineError class with pipelineFlow, serverName, and operation properties
- Detect Mcpd-Error-Type header on 500 responses (request-pipeline-failure, response-pipeline-failure)
- Enrich PipelineError with server/tool context when called through performCall
- Export PipelineFlow type and PIPELINE_FLOW_REQUEST/PIPELINE_FLOW_RESPONSE constants
- Add comprehensive tests for pipeline error handling
- Update README with PipelineError documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New public PipelineError type and pipeline flow constants to surface pipeline failures.
  * Richer error diagnostics that preserve pipeline flow and attach server/operation context.
  * Existing error behaviours retained as fallback for non-pipeline failures.

* **Documentation**
  * README updated with PipelineError semantics and examples.

* **Tests**
  * Expanded tests covering pipeline error detection, flows and context propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->