### PR TITLE
Use corepack to activate npm in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Activate npm from packageManager field
         run: |
-          corepack enable
-          corepack prepare npm@11.6.2 --activate
+          corepack enable npm
+          corepack install
           npm --version
 
       - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,11 +35,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: '22'
+          node-version: '22.22.2'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install latest npm
-        run: npm install -g npm@latest
+      - name: Activate npm from packageManager field
+        run: |
+          corepack enable
+          corepack prepare npm@11.6.2 --activate
+          npm --version
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Replace `npm install -g npm@latest` with a corepack step that activates the `npm@11.6.2` version pinned in `package.json`'s `packageManager` field.
- Pin `node-version` to `22.22.2` so CI does not silently pick up a new toolcache image.

## Background
The release workflow failed on the previous tag (run [24660464747](https://github.com/mozilla-ai/mcpd-sdk-javascript/actions/runs/24660464747/job/72104818768)) with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
```

The bundled npm in the Node 22.22.2 toolcache image is corrupt (its `@npmcli/arborist` install is missing the `promise-retry` dependency), so the `npm install -g npm@latest` self-upgrade cannot run. That step was also unnecessary, as Node 22 already ships an npm version that supports `npm publish --provenance` (added in 9.5.0).

## Root fix
Corepack fetches npm directly from the registry, so it sidesteps the broken bundled global npm entirely. Activating the version declared in `packageManager` keeps CI reproducible and aligned with local development. Pinning the Node version guards against future toolcache regressions.

## Test plan
- [ ] Trigger the workflow via `workflow_dispatch` against a dry-run tag and confirm the corepack step prints `11.6.2`.
- [ ] Confirm `npm ci`, `npm run build`, and `npm publish --provenance` all succeed.
- [ ] Cut a real release tag once the dry run passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned Node runtime to a specific patch version to improve build consistency.
  * Switched npm management to use Corepack (enable/install and verification) instead of a global npm upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->